### PR TITLE
Compare gRASPA installation patches

### DIFF
--- a/Cluster-Setup/NERSC/readme.md
+++ b/Cluster-Setup/NERSC/readme.md
@@ -44,9 +44,9 @@ Modify line 65 in `patch.py` file to `patch_model=['Allegro']`. Then,
 ```shellscript
 python patch.py
 ```
-Now the patched source code is in `patch_libtorch_Allegro/`. Go into the patched folder, and we have some final work to do.
+Now the patched source code is in `patch_Allegro/`. Go into the patched folder, and we have some final work to do.
 ```shellscript
-cd patch_libtorch_Allegro/
+cd patch_Allegro/
 ```
 If you are using the Lin model, modify line 64 in `patch.py` to `tf_or_torch = ['cppflow']` and line 65 to `patch_model=['LCLIN']`. Then do the similar steps to those for the Allegro model. The patched code will be in `patch_cppflow_LCLIN` folder.
 # Step 6

--- a/Cluster-Setup/NERSC_Installation_Nov2025/readme.md
+++ b/Cluster-Setup/NERSC_Installation_Nov2025/readme.md
@@ -63,11 +63,11 @@ Modify line 65 in `patch.py` file to `patch_model=['Allegro']`. Then,
 ```shellscript
 python patch.py
 ```
-Now the patched source code is in `patch_libtorch_Allegro/`. Go into the patched folder, and we have some final work to do.
+Now the patched source code is in `patch_Allegro/`. Go into the patched folder, and we have some final work to do.
 ```shellscript
-cd patch_libtorch_Allegro/
+cd patch_Allegro/
 ```
-If you are using the Lin model, modify line 64 in `patch.py` to `tf_or_torch = ['cppflow']` and line 65 to `patch_model=['LCLIN']`. Then do the similar steps to those for the Allegro model. The patched code will be in `patch_cppflow_LCLIN` folder.
+If you are using the Lin model, modify line 64 in `patch.py` to `tf_or_torch = ['cppflow']` and line 65 to `patch_model=['LCLIN']`. Then do the similar steps to those for the Allegro model. The patched code will be in `patch_LCLIN/`.
 
 # Step 6
 Finally, we need to modify the source code due to NERSC configuration:


### PR DESCRIPTION
Update NERSC installation READMEs to reflect actual `patch.py` output directory names.

The previous instructions specified incorrect output directory names (e.g., `patch_libtorch_Allegro/` instead of `patch_Allegro/` and `patch_cppflow_LCLIN` instead of `patch_LCLIN`), which would cause "No such file or directory" errors when following the steps. This PR corrects these discrepancies to match the `patch.py` script's behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-39514852-85b4-458b-8b08-169936624704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39514852-85b4-458b-8b08-169936624704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix README paths to correct patched output directory names for Allegro and LCLIN.
> 
> - **Docs (NERSC setup)**:
>   - Update patched output directory names in `Cluster-Setup/NERSC/readme.md`:
>     - `patch_libtorch_Allegro/` ➜ `patch_Allegro/` (and corresponding `cd` command).
>   - Update patched output directory names in `Cluster-Setup/NERSC_Installation_Nov2025/readme.md`:
>     - `patch_libtorch_Allegro/` ➜ `patch_Allegro/` (and corresponding `cd` command).
>     - `patch_cppflow_LCLIN` ➜ `patch_LCLIN/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 985bbee38863802956e9507d84eacaecbcf56738. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->