### PR TITLE
Lennard-Jones parameter update

### DIFF
--- a/src_clean/data_struct.h
+++ b/src_clean/data_struct.h
@@ -1345,6 +1345,7 @@ struct Atom_FF //Atom definitions, epsilon, sigma, charge//
   std::string Name;
   double epsilon;
   double sigma;
+  double C4 = 0.0;
   bool   shift = false;
   bool   tail  = false;
 };

--- a/src_clean/read_data.cpp
+++ b/src_clean/read_data.cpp
@@ -793,6 +793,7 @@ void ForceFieldParser(Input_Container& Input, PseudoAtomDefinitions& PseudoAtom)
       AtomFF.Name    = termsScannedLined[0];
       AtomFF.epsilon = std::stod(termsScannedLined[2]);
       AtomFF.sigma   = std::stod(termsScannedLined[3]);
+      if(termsScannedLined.size() > 4) AtomFF.C4 = std::stod(termsScannedLined[4]);
       AtomFF.shift   = shifted;
       AtomFF.tail    = tail;
       


### PR DESCRIPTION
Add `C4` parameter to `Atom_FF` struct and enable parsing it from input files to support the 12-6-4 Lennard-Jones potential.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f5bcc2c-054f-4a74-b432-1c790adf8836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f5bcc2c-054f-4a74-b432-1c790adf8836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `C4` to `Atom_FF` and reads it (optional 5th column) in `ForceFieldParser` from `force_field_mixing_rules.def`.
> 
> - **Force field**:
>   - Add `C4` (default `0.0`) to `Atom_FF` in `src_clean/data_struct.h`.
>   - Parse optional `C4` value in `ForceFieldParser` (`src_clean/read_data.cpp`) when present as the 5th token in `force_field_mixing_rules.def`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bb0baecd205cfeb0584c7210c71ea4a23b824c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->