### PR TITLE
Fix OOB cudaMemcpy in single-particle blockpocket check (issue #80)

### DIFF
--- a/src_clean/mc_single_particle.h
+++ b/src_clean/mc_single_particle.h
@@ -99,8 +99,11 @@ inline void SingleBody_Prepare(Variables& Vars, size_t systemId)
     SystemComponents.CurrentBlockedPocketMoveType = move_type;
     
     // Check all atoms in the molecule (matching RASPA2: for(i=0;i<nr_atoms;i++) if(BlockedPocket(TrialPosition[i])) return 0;)
+    // get_new_position writes the proposed positions at Sims.New.pos[0..Molsize); start_position only offsets reads from d_a.
+    // Reading at start_position overruns the 1024-slot temporary buffer once a component exceeds 85 molecules (issue #80).
     std::vector<double3> trial_positions(Molsize);
-    cudaMemcpy(trial_positions.data(), &Sims.New.pos[start_position], Molsize * sizeof(double3), cudaMemcpyDeviceToHost);
+    cudaMemcpy(trial_positions.data(), Sims.New.pos, Molsize * sizeof(double3), cudaMemcpyDeviceToHost);
+    checkCUDAError("error copying proposed positions for blockpocket check (single-particle move)");
     
     for(size_t i = 0; i < Molsize; i++)
     {


### PR DESCRIPTION
The blockpocket check in SingleBody_Prepare copied the proposed trial positions from Sims.New.pos at offset start_position (= SelectedMolInComponent * Moleculesize). But get_new_position writes the proposed positions at Sims.New.pos[0..Molsize); start_position only offsets reads from d_a. Sims.New is the fixed 1024-slot temporary buffer (Setup_Temporary_Atoms_Structure), so:

1. For molecule index >= 1 the check silently tested stale/garbage coordinates against the block pockets (wrong physics, no error).
2. Once a component exceeded 85 molecules (Molsize 12: 12*85+12 > 1024) the device range left the allocation and cudaMemcpy returned cudaErrorInvalidValue. The error is sticky and surfaced at the next cudaGetLastError check, typically as "CUDA Error: error Initializing Ewald Vectors: invalid argument" (Ewald_Energy_Functions.h:529) -- the crash reported in snurr-group/gRASPA#80 for xylene isotherms in FORXAM at high pressure (p-xylene crossing 86 molecules).

Fix: copy from offset 0 and check the memcpy result loudly.

Verified on Quest A100 (CUDA 11.8): standalone probe confirms offset 1020+12 copy returns "invalid argument" while 1008+12 is clean; trigger case (90 o-xylene + BlockPockets) reproduces the verbatim issue #80 error on HEAD and completes with this fix; BlockPockets-off and 84-molecule controls run clean on HEAD; compute-sanitizer names the failing call (cudaErrorInvalidValue on cudaMemcpy); no-blockpocket MOF regression case is score.py-constant between HEAD and this fix.