### PR TITLE
Fix Gibbs volume-move step controller: use accepted/attempts ratio

### DIFF
--- a/src_clean/mc_box.h
+++ b/src_clean/mc_box.h
@@ -487,7 +487,8 @@ static inline void Update_Max_GibbsVolume(Gibbs& GibbsStatistics)
 {
   if(GibbsStatistics.GibbsBoxStats.x > 0)
   {
-    double ratio = static_cast<double>(GibbsStatistics.GibbsBoxStats.x) / static_cast<double>(GibbsStatistics.GibbsBoxStats.y);
+    //ratio = accepted/attempts (x=attempts, y=accepted); RASPA2 convention. Inverting it drives MaxGibbsBoxChange to the ceiling//
+    double ratio = static_cast<double>(GibbsStatistics.GibbsBoxStats.y) / static_cast<double>(GibbsStatistics.GibbsBoxStats.x);
     double vandr = ratio/GibbsStatistics.TargetAccRatioVolumeChange;
     if(vandr > 1.5) vandr = 1.5;
     else if(ratio < 0.5) vandr = 0.5;


### PR DESCRIPTION
Update_Max_GibbsVolume computed the adaptive volume-move acceptance ratio as attempts/accepted (GibbsBoxStats.x / GibbsBoxStats.y) instead of accepted/attempts. Since accepted <= attempts, that ratio is always >= 1, so vandr = ratio / TargetAccRatioVolumeChange (target 0.5) is always >= 2 and clamps to 1.5 on every recalibration, driving MaxGibbsBoxChange up to its 0.5 ceiling regardless of the true acceptance rate. This is a sign-inverted feedback loop (low acceptance -> bigger volume moves -> even lower acceptance), so Gibbs-ensemble volumes blow up.

Swap numerator and denominator to match RASPA2's accepted/attempts convention.

Verified on Quest (A100) via git-worktree A/B with RandomSeed 0: every non-Gibbs Example is bit-identical (score.py, no comparison-class failures); the change is confined to runs that perform Gibbs volume moves (GibbsVolumeChangeProbability > 0, two boxes). Extended NVT-Gibbs volume acceptance moves from 2.47% (buggy) to 48.17% (fixed; target 50%).

Reported by Logan.